### PR TITLE
Update requirements-train.txt

### DIFF
--- a/TRAINING.md
+++ b/TRAINING.md
@@ -251,7 +251,7 @@ If you simply want to measure the accuracy of your model on a dataset, you can u
 python evaluate.py \
     --dataset CIFAR10 \
     --base_network norm_ablations_final \
-    --experiment_name resnet_20_bnu-linear-nomaxout
+    --experiment_name resnet_20_bnu-linear-nomaxout \
     --reload last
 ```
 

--- a/requirements-train.txt
+++ b/requirements-train.txt
@@ -1,6 +1,6 @@
 # this will allow you to run all the basic things like training and inference
 einops
-pytorch-lightning>=1.8.0
+pytorch-lightning>=1.8.0,<2.0.0
 torch>=1.13
 torchvision
 torchmetrics>=0.11.0


### PR DESCRIPTION
Limit pytorch-lightning version to be less than 2.0.0, as versions from 2.0.0 upwards seem to be incompatible.
Specifically, it breaks when running training script, e.g.:
`python train.py --dataset CIFAR10 --base_network norm_ablations_final --experiment_name resnet_56-nomaxout`

output:

> TypeError: ClassificationLitModel.configure_gradient_clipping() missing 1 required positional argument: 'optimizer_idx'